### PR TITLE
remove static metadata

### DIFF
--- a/pip_abandoned/__version__.py
+++ b/pip_abandoned/__version__.py
@@ -1,1 +1,3 @@
-__version__ = "0.4.1"
+from importlib.metadata import version
+
+__version__ = version("pip-abandoned")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pip-abandoned"
+version = "0.4.2"
 authors = [{name = "chris48s", email = "git@chris-shaw.dev"}]
 description = "Search for abandoned and deprecated python packages"
 readme = "README.md"
@@ -19,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
     "keyring>=19",
@@ -37,6 +37,7 @@ dev = [
     "pytest==8.3.3",
     "pytest-cov==5.0.0",
     "responses==0.25.3",
+    "tomlkit==0.13.0",
 ]
 
 [project.urls]

--- a/release.sh
+++ b/release.sh
@@ -32,7 +32,7 @@ then
 fi
 
 # confirm
-read -r -p "Bump version from $(cut -d '"' -f2 < pip_abandoned/__version__.py) to $VERSION. Are you sure? [y/n] " response
+read -r -p "Bump version from $(python version.py show) to $VERSION. Are you sure? [y/n] " response
 response=${response,,}  # tolower
 if [[ ! "$response" =~ ^(yes|y)$ ]]; then
     exit 1
@@ -41,11 +41,10 @@ fi
 # checks done, now publish the release...
 
 # bump version
-echo '__version__ = "'"$VERSION"'"' > pip_abandoned/__version__.py
+python version.py bump "$VERSION"
 
 # commit
 git add pyproject.toml
-git add pip_abandoned/__version__.py
 git add CHANGELOG.md
 git commit -m "version $VERSION"
 

--- a/version.py
+++ b/version.py
@@ -1,0 +1,36 @@
+import argparse
+import sys
+
+import tomlkit
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Manage version in pyproject.toml",
+    )
+    subparsers = parser.add_subparsers(
+        required=True, dest="subcommand", title="subcommands"
+    )
+    subparsers.add_parser("show", help="Show current version")
+    bump = subparsers.add_parser("bump", help="Bump version")
+    bump.add_argument("version", help="new version")
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+
+    with open("./pyproject.toml", "r") as f:
+        data = tomlkit.load(f)
+
+    if args.subcommand == "show":
+        print(data["project"]["version"])
+    elif args.subcommand == "bump":
+        data["project"]["version"] = args.version
+        with open("./pyproject.toml", "w") as f:
+            tomlkit.dump(data, f)
+    else:
+        parser.print_help()
+
+    sys.exit(0)


### PR DESCRIPTION
This PR would switch from using `dynamic = ["version"]` and `__version__` as the source of truth to using `importlib.metadata.version` and `pyproject.toml` as the source of truth.

Some notes:

- importlib is available in python >=3.10. For older versions you have to require importlib-metadata. That isn't a problem for this library because I'm already doing that and using importlib for other things. For other libraries it would be quite annoying to pull in a whole library for the sake of a version number. I'd be inclined to only do this more widely if I'm dropping python < 3.10
- Flit doesn't have a command for bumping the version number and is unlikely to gain one. We can make a little utility for this, but python doesn't have a library that can write toml files in the standard library. In >= 3.11, there is a toml _reader_ the standard lib but no _writer_. So we have to pull in a toml library to do this. It only has to be a dev dependency, but it is another package. You could avoid this by either switching to another build tool (e.g: hatch) or doing the version bump by hand.

Other places to update/account for this:

- https://github.com/chris48s/geometry-to-spatialite/
- https://github.com/chris48s/cookiecutter-python-package/
- https://github.com/chris48s/python-package-shared/blob/c21e93468cf4fa39aa99b5bea26d1ec2aabe2c38/.github/workflows/write-badges-pep621.yml#L67-L73
